### PR TITLE
Add destination namespace option for the convert command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # tiller-releases-converter changelog
 
+## 0.1.2 (Jul 12, 2019)
+
+- (New) optional flag to set convert namespace destination
+
 ## 0.1.1 (Jun 25, 2018)
 
 - (Fix) fixing naming problem "converter" vs "convertor"

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -51,7 +51,7 @@ func createSecretFromConfigMap(configMap corev1.ConfigMap) error {
 	}
 
 	// Create a new Secret resource with data from an old ConfigMap
-	_, err := clientset.CoreV1().Secrets(nameSpace).Create(&newSecret)
+	_, err := clientset.CoreV1().Secrets(destinationNameSpace).Create(&newSecret)
 
 	return err
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,11 +23,11 @@ var (
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	convertCmd.LocalFlags().StringVarP(&destinationNameSpace, "destination-namespace", "d", "", "destination tiller namespace (default is set to namespace flag)")
-
 	rootCmd.PersistentFlags().StringVar(&kubeContext, "context", "", "kube config context")
 	rootCmd.PersistentFlags().StringVarP(&kubeConfig, "kubeconfig", "c", "", "config file (default is $HOME/.kube/config)")
 	rootCmd.PersistentFlags().StringVarP(&nameSpace, "namespace", "n", "", "tiller namespace (default is kube-system)")
+
+	convertCmd.Flags().StringVarP(&destinationNameSpace, "destination-namespace", "d", "", "destination tiller namespace (default is set to namespace flag)")
 
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(convertCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,15 +12,18 @@ import (
 )
 
 var (
-	kubeContext string
-	kubeConfig  string
-	nameSpace   string
+	kubeContext          string
+	kubeConfig           string
+	nameSpace            string
+	destinationNameSpace string
 
 	clientset *kubernetes.Clientset
 )
 
 func init() {
 	cobra.OnInitialize(initConfig)
+
+	convertCmd.LocalFlags().StringVarP(&destinationNameSpace, "destination-namespace", "d", "", "destination tiller namespace (default is set to namespace flag)")
 
 	rootCmd.PersistentFlags().StringVar(&kubeContext, "context", "", "kube config context")
 	rootCmd.PersistentFlags().StringVarP(&kubeConfig, "kubeconfig", "c", "", "config file (default is $HOME/.kube/config)")
@@ -56,6 +59,10 @@ func initConfig() {
 
 	if nameSpace == "" {
 		nameSpace = "kube-system"
+	}
+
+	if destinationNameSpace == "" {
+		destinationNameSpace = nameSpace
 	}
 
 	config, err := getKubeConfig()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,7 +41,7 @@ var rootCmd = &cobra.Command{
 	Long: `A converter for Tiller's releases from ConfigMaps to Secrets
 to migrate a default Tiller installation to a more secure one,
 which uses K8s secrets as its backend.`,
-	Version: "0.1.1",
+	Version: "0.1.2",
 }
 
 func Execute() {


### PR DESCRIPTION
@dragonsmith 

I have the use case of while converting from unsecure to secure, we also moved our namespace of our tiller install. This might not be used by many, but I decided to let you make that decision.